### PR TITLE
Python requires consistent indentation.

### DIFF
--- a/GeneNet.py
+++ b/GeneNet.py
@@ -12,25 +12,25 @@ from Model import dt
 # Optimizer 
 
 def AdamOptimizer(cost, params, lr=0.1, b1=0.02, b2=0.001, e=1e-8):
-    updates = []
-    grads = T.grad(cost, params)
-    i = theano.shared(np.float32(1))
-    i_t = i + 1.
-    fix1 = 1. - (1. - b1)**i_t
-    fix2 = 1. - (1. - b2)**i_t
-    lr_t = lr * (T.sqrt(fix2) / fix1)
-    for p, g in zip(params, grads):
-    	m = theano.shared(np.zeros(p.get_value().shape, dtype=theano.config.floatX))
-    	v = theano.shared(np.zeros(p.get_value().shape, dtype=theano.config.floatX))
-        m_t = (b1 * g) + ((1. - b1) * m)
-        v_t = (b2 * T.sqr(g)) + ((1. - b2) * v)
-        g_t = m_t / (T.sqrt(v_t) + e)
-        p_t = p - (lr_t * g_t)
-        updates.append((m, m_t))
-        updates.append((v, v_t))
-        updates.append((p, p_t))
-    updates.append((i, i_t))
-    return updates
+	updates = []
+	grads = T.grad(cost, params)
+	i = theano.shared(np.float32(1))
+	i_t = i + 1.
+	fix1 = 1. - (1. - b1)**i_t
+	fix2 = 1. - (1. - b2)**i_t
+	lr_t = lr * (T.sqrt(fix2) / fix1)
+	for p, g in zip(params, grads):
+		m = theano.shared(np.zeros(p.get_value().shape, dtype=theano.config.floatX))
+		v = theano.shared(np.zeros(p.get_value().shape, dtype=theano.config.floatX))
+		m_t = (b1 * g) + ((1. - b1) * m)
+		v_t = (b2 * T.sqr(g)) + ((1. - b2) * v)
+		g_t = m_t / (T.sqrt(v_t) + e)
+		p_t = p - (lr_t * g_t)
+		updates.append((m, m_t))
+		updates.append((v, v_t))
+		updates.append((p, p_t))
+	updates.append((i, i_t))
+	return updates
 
 
 ####################################################################


### PR DESCRIPTION
The AdamOptimizer() function's indentation has some lines that are all
spaces and some are mixed spaces and tabs. At least with Python 3.6.8,
this causes a

TabError: inconsistent use of tabs and spaces in indentation

Switched all indentation in the function to be tab-based, since the
rest of the file is tab indented.